### PR TITLE
CSS2Properties styleIndex was shared across all instances

### DIFF
--- a/specs/css/boot.js
+++ b/specs/css/boot.js
@@ -14,6 +14,7 @@ load('dist/dom.js');
 load('dist/event.js');
 load('dist/html.js');
 load('dist/css.js');
+load('dist/parser.js');
 load('specs/css/spec.js');
 start();
 

--- a/specs/css/spec.js
+++ b/specs/css/spec.js
@@ -179,3 +179,10 @@ test('box model', function(){
 	ok(true, "Box Model Test - Broken: Fix Me");
 	//equals(div2.offsetWidth , 1500, 'box model width should be 1500');
 });
+
+test('innerHTML with style attributes', function () {
+  var div = document.createElement('div');
+  div.innerHTML = '<div id="foo" style="display:none;">test</div>';
+
+  equals(div.firstChild.style.display, 'none', '.firstChild.style.display');
+});

--- a/specs/css/spec.js
+++ b/specs/css/spec.js
@@ -86,6 +86,19 @@ test('CSS2Properties', function(){
     equals(div.style.cssText, 'display: block; height: 300px; width: 400px; opacity: 0.5; position: absolute;', '.style.cssText');
 });
 
+test('CSS2Properties across elements', function(){
+  var div = document.createElement('div');
+
+  equals(div.style.display, 'block', '.style.display');
+
+  div.setAttribute('style','display:none;');
+  equals(div.style.display, 'none', '.style.display');
+
+  var div2 = document.createElement('div');
+
+  equals(div2.style.display, 'block', '.style.display');
+});
+
 test('document.styleSheets', function() {
     ok(document.styleSheets, 'document.styleSheets exists');
     equals(document.styleSheets.toString(), '[object StyleSheetList]', 'StyleSheetsList.toString()');

--- a/specs/html/spec.js
+++ b/specs/html/spec.js
@@ -859,3 +859,10 @@ test("Option", function() {
     x = new Option('text1', 'value1');
     x = new Option('text2', 'value2', true, true);
 });
+
+test("Event Handlers Defined", function() {
+    var a=document.createElement("a");
+    ok(a["onfocus"], "html events defined");
+    ok(a["onclick"], "mouse events defined");
+    ok(a["onkeydown"], "keyboard events defined");
+});

--- a/specs/html/spec.js
+++ b/specs/html/spec.js
@@ -866,3 +866,21 @@ test("Event Handlers Defined", function() {
     ok(a["onclick"], "mouse events defined");
     ok(a["onkeydown"], "keyboard events defined");
 });
+
+test("Event Handlers Invoked on Inline Attributes", function() {
+	try {
+		// enable eval of inline scripts for the duration of this test
+		Envjs.scriptTypes[""]=true;
+		
+	    var a=document.createElement("a");
+	    ok(a, "created anchor tag");
+	    a.setAttribute("onclick", "ok(true,'event invoked on an inline handler');");
+	    
+	    var event = document.createEvent('MouseEvents');
+	    ok(event, "created event");
+	    event.initEvent('click', true, true);
+	    a.dispatchEvent(event);
+	} finally {
+		Envjs.scriptTypes[""]=false;
+	}
+});

--- a/src/css/properties.js
+++ b/src/css/properties.js
@@ -23,7 +23,7 @@ var __toDashed__ = function(camelCaseName) {
 
 CSS2Properties = function(element){
     //console.log('css2properties %s', __cssproperties__++);
-    this.styleIndex = __supportedStyles__;//non-standard
+    this.styleIndex = __extend__({}, __supportedStyles__);//non-standard
     this.type = element.tagName;//non-standard
     __setArray__(this, []);
     __cssTextToStyles__(this, element.cssText || '');

--- a/src/css/properties.js
+++ b/src/css/properties.js
@@ -26,7 +26,9 @@ CSS2Properties = function(element){
     this.styleIndex = __extend__({}, __supportedStyles__);//non-standard
     this.type = element.tagName;//non-standard
     __setArray__(this, []);
-    __cssTextToStyles__(this, element.cssText || '');
+
+    var style = element.attributes && element.attributes.getNamedItem('style');
+    __cssTextToStyles__(this, element.cssText || (style && style.value) || '');
 };
 __extend__(CSS2Properties.prototype, {
     get cssText() {

--- a/src/event/eventtarget.js
+++ b/src/event/eventtarget.js
@@ -120,7 +120,10 @@ function __dispatchEvent__(target, event, bubbles){
             });
         }
         if (target["on" + event.type]) {
-            target["on" + event.type](event);
+            var returnValue=target["on" + event.type](event);
+            if (returnValue === false) {
+            	event.preventDefault();
+            }
         }
         if (bubbles && !event.cancelled){
             __bubbleEvent__(target, event);

--- a/src/html/element.js
+++ b/src/html/element.js
@@ -41,6 +41,8 @@ HTMLElement = function(ownerDocument) {
 
 HTMLElement.prototype = new Element();
 __extend__(HTMLElement.prototype, HTMLEvents.prototype);
+__extend__(HTMLElement.prototype, MouseEvents.prototype);
+__extend__(HTMLElement.prototype, KeyboardEvents.prototype);
 __extend__(HTMLElement.prototype, {
     get className() {
         return this.getAttribute("class")||'';

--- a/src/html/htmlevents.js
+++ b/src/html/htmlevents.js
@@ -9,7 +9,10 @@ var __eval__ = function(script, node){
     if (!script == "" && Envjs.scriptTypes['']){
         // don't assemble environment if no script...
         try{
-            Envjs.eval(node.ownerDocument.ownerWindow, script, script+" ("+node+")");
+        	// wrap the inline handler in a double enclosure so we can correctly handle the return value
+        	// otherwise we get "error evaluating  InternalError: invalid return"
+        	var exec="(function(){var result=(function(){"+script+"})(); return result;})()";
+        	Envjs.eval(node.ownerDocument.ownerWindow, exec, script+" ("+node+")");
         }catch(e){
             console.log('error evaluating %s', e);
         }


### PR DESCRIPTION
I was seeing a problem that when a node was created and then was set to hidden by jQuery, any node I created after that point would also be hidden.
I looked into the code and CSS2Properties' styleIndex was getting set to **supportedStyles**.  Any modifications to styleIndex would also update **supportedStyles**, so further instances of CSS2Properties will also get those changes.
I've updated it to instead make a clone using **extend** and also added a test for the issue.

Thanks for the extremely useful project!
