### PR TITLE
Fixing filesystem paths in Envjs.uri

### DIFF
--- a/specs/platform/core.js
+++ b/specs/platform/core.js
@@ -35,6 +35,8 @@ test('Envjs.uri', function(){
     ok(uri, 'Able to create uri');
     equals(uri, 'http://envjs.com/specs/env/spec.html', 'uri');
     equals(uri.toString(), 'http://envjs.com/specs/env/spec.html', 'uri');
+	
+	document = null;
 
     uri = Envjs.uri('http://envjs.com/specs/env/spec.html');
     ok(uri, 'Able to create uri');

--- a/specs/platform/core.js
+++ b/specs/platform/core.js
@@ -36,8 +36,6 @@ test('Envjs.uri', function(){
     equals(uri, 'http://envjs.com/specs/env/spec.html', 'uri');
     equals(uri.toString(), 'http://envjs.com/specs/env/spec.html', 'uri');
 
-    document = null;
-
     uri = Envjs.uri('http://envjs.com/specs/env/spec.html');
     ok(uri, 'Able to create uri');
     equals(uri, 'http://envjs.com/specs/env/spec.html', 'uri');
@@ -53,6 +51,15 @@ test('Envjs.uri', function(){
 
     uri = Envjs.uri('file:///foo/bar/');
     equals(uri, 'file:///foo/bar/', 'File, absolute, with ending "/"');
+	
+	// handle windows style file paths, firefox will convert this to a file: URL
+	uri = Envjs.uri('C:\\foo\\bar\\index.html');
+    equals(uri, 'file:///C:/foo/bar/index.html', 'File, absolute, converted slashes');
+
+	// when there is no document and you pass a relative path, it should be converted to a file: URL
+    document = null;
+    uri = Envjs.uri('specs/env/spec.html');
+    ok(/file\:\/\/\/.*\/specs\/env\/spec.html/.test(uri), 'Relative filesystem paths work');
 
     uri = Envjs.uri('http://foo.com');
     equals(uri, 'http://foo.com/', 'http, absolute, without path, without ending "/"');

--- a/src/console/__global__.js
+++ b/src/console/__global__.js
@@ -2,5 +2,5 @@
 /**
  * @author envjs team
  */
-var Console,
-    console;
+/*var Console,
+    console;*/

--- a/src/css/__global__.js
+++ b/src/css/__global__.js
@@ -2,7 +2,7 @@
 /**
  * DOM Style Level 2
  */
-var CSS2Properties,
+/*var CSS2Properties,
     CSSRule,
     CSSStyleRule,
     CSSImportRule,
@@ -13,4 +13,4 @@ var CSS2Properties,
     CSSStyleSheet,
     StyleSheet,
     StyleSheetList;
-;
+;*/

--- a/src/dom/__global__.js
+++ b/src/dom/__global__.js
@@ -13,7 +13,7 @@
  * be able to correctly implement to core browser DOM interfaces."
  */
 
-var Attr,
+/*var Attr,
     CDATASection,
     CharacterData,
     Comment,
@@ -35,5 +35,5 @@ var Attr,
     Range,
     XMLSerializer,
     DOMParser;
-
+*/
 

--- a/src/event/__global__.js
+++ b/src/event/__global__.js
@@ -7,7 +7,7 @@
  * This file simply provides the global definitions we need to
  * be able to correctly implement to core browser DOM Event interfaces.
  */
-var Event,
+/*var Event,
     MouseEvent,
     UIEvent,
     KeyboardEvent,
@@ -17,4 +17,4 @@ var Event,
     EventException,
     //nonstandard but very useful for implementing mutation events
     //among other things like general profiling
-    Aspect;
+    Aspect;*/

--- a/src/html/__global__.js
+++ b/src/html/__global__.js
@@ -6,7 +6,7 @@
  * This file simply provides the global definitions we need to
  * be able to correctly implement to core browser DOM HTML interfaces.
  */
-var HTMLDocument,
+/*var HTMLDocument,
     HTMLElement,
     HTMLCollection,
     HTMLAnchorElement,
@@ -64,3 +64,4 @@ var HTMLDocument,
     Option,
     __loadImage__,
     __loadLink__;
+*/

--- a/src/parser/__global__.js
+++ b/src/parser/__global__.js
@@ -2,7 +2,6 @@
 //these are both non-standard globals that
 //provide static namespaces and functions
 //to support the html 5 parser from nu.
-var XMLParser = {},
-    HTMLParser = {};
-
+XMLParser = {};
+HTMLParser = {};
     

--- a/src/parser/htmldocument.js
+++ b/src/parser/htmldocument.js
@@ -155,6 +155,9 @@ var __elementPopped__ = function(ns, name, node){
                                     doc.parsing = false;
                                     //DOMContentLoaded event
                                     try{
+										if ( Envjs.killTimersAfterLoad === true ) {
+											Envjs.clear();
+										}
 										if ( Envjs.fireLoad === false ) {
 											return;
 										}

--- a/src/parser/htmldocument.js
+++ b/src/parser/htmldocument.js
@@ -155,6 +155,9 @@ var __elementPopped__ = function(ns, name, node){
                                     doc.parsing = false;
                                     //DOMContentLoaded event
                                     try{
+										if ( Envjs.fireLoad === false ) {
+											return;
+										}
                                         if(doc.createEvent){
                                             event = doc.createEvent('Events');
                                             event.initEvent("DOMContentLoaded", false, false);

--- a/src/platform/core/__global__.js
+++ b/src/platform/core/__global__.js
@@ -5,7 +5,7 @@
  * Copyright 2008-2010 John Resig, under the MIT License
  */
 
-var Envjs = function(){
+Envjs = function(){
     var i,
         name,
         override = function(){

--- a/src/platform/core/__global__.js
+++ b/src/platform/core/__global__.js
@@ -30,6 +30,10 @@ var Envjs = function(){
         override(arguments[1]);
         window.location = arguments[0];
     }
+	if (Envjs.dontPrintUserAgent !== true && Envjs.printedUserAgent !== true) {
+		Envjs.printedUserAgent = true;
+		console.log('[ %s ]', window.navigator.userAgent);
+	}
     return;
 },
 __this__ = this;

--- a/src/platform/core/html.js
+++ b/src/platform/core/html.js
@@ -40,6 +40,9 @@ Envjs.loadInlineScript = function(script){
             'eval('+script.text.substring(0,16)+'...):'+new Date().getTime()
         );
     }
+	if ( Envjs.afterInlineScriptLoad ) {
+		Envjs.afterInlineScriptLoad(script)
+	}
     //console.log('evaluated at scope %s \n%s',
     //    script.ownerDocument.ownerWindow.guid, script.text);
 };

--- a/src/platform/core/xhr.js
+++ b/src/platform/core/xhr.js
@@ -14,6 +14,7 @@ Envjs.getcwd = function() {
  * @param {Object} base  (semi-optional)  The base url used in resolving "path" above
  */
 Envjs.uri = function(path, base) {
+	path = path.replace(/\\/g, '/');
     //console.log('constructing uri from path %s and base %s', path, base);
 
     // Semi-common trick is to make an iframe with src='javascript:false'
@@ -25,6 +26,12 @@ Envjs.uri = function(path, base) {
     // if path is absolute, then just normalize and return
     if (path.match('^[a-zA-Z]+://')) {
         return urlparse.urlnormalize(path);
+    }
+
+    // if path is a Windows style absolute path (C:\foo\bar\index.html)
+	// make it a file: URL
+    if (path.match('^[a-zA-Z]+:/')) {
+        return 'file:///' + urlparse.urlnormalize(path);
     }
 
     // interesting special case, a few very large websites use
@@ -48,7 +55,7 @@ Envjs.uri = function(path, base) {
     // if base is still empty, then we are in QA mode loading local
     // files.  Get current working directory
     if (!base) {
-        base = 'file://' +  Envjs.getcwd() + '/';
+        base = 'file:///' + (""+Envjs.getcwd()).replace(/\\/g, '/') + '/';
     }
     // handles all cases if path is abosulte or relative to base
     // 3rd arg is "false" --> remove fragments

--- a/src/platform/rhino/__global__.js
+++ b/src/platform/rhino/__global__.js
@@ -5,7 +5,7 @@
  * Copyright 2008-2010 John Resig, under the MIT License
  */
 
-var __context__ = Packages.org.mozilla.javascript.Context.getCurrentContext();
+__context__ = Packages.org.mozilla.javascript.Context.getCurrentContext();
 
 Envjs.platform       = "Rhino";
 Envjs.revision       = "1.7.0.rc2";

--- a/src/timer/__global__.js
+++ b/src/timer/__global__.js
@@ -10,10 +10,10 @@
  * 
  * requires Envjs.wait, Envjs.sleep, Envjs.WAIT_INTERVAL
  */
-var setTimeout,
+/*var setTimeout,
     clearTimeout,
     setInterval,
     clearInterval;
-
+*/
 
     

--- a/src/timer/timer.js
+++ b/src/timer/timer.js
@@ -11,6 +11,18 @@ $timers.lock = function(fn){
     Envjs.sync(fn)();
 };
 
+Envjs.clear = function(){
+    $timers.lock(function(){
+		for(var i=0; i<$timers.length; i++) {
+			if ( !$timers[i] ) {
+				continue;
+			}
+            $timers[i].stop();
+            delete $timers[i];
+        }
+    });
+}
+
 //private internal class
 var Timer = function(fn, interval){
     this.fn = fn;

--- a/src/window/__global__.js
+++ b/src/window/__global__.js
@@ -2,8 +2,8 @@
 /**
  * @todo: document
  */
-var Window,
+/*var Window,
     Screen,
     History,
     Navigator;
-
+*/

--- a/src/window/window.js
+++ b/src/window/window.js
@@ -326,4 +326,3 @@ Window = function(scope, parent, opener){
 //finally pre-supply the window with the window-like environment
 //console.log('Default Window');
 new Window(__this__, __this__);
-console.log('[ %s ]',window.navigator.userAgent);

--- a/src/xhr/__global__.js
+++ b/src/xhr/__global__.js
@@ -10,5 +10,6 @@
  * be able to correctly implement to core browser (XML)HTTPRequest 
  * interfaces.
  */
-var Location,
+/*var Location,
     XMLHttpRequest;
+*/


### PR DESCRIPTION
This pull requests fixes 2 issues and adds a test for both:

1) If you put in an absolute windows path in any browser, like this: C:\foo\bar\index.html, it will convert it to file:///C:/foo/bar/index.html.

2) If you have document=null and you try to open a relative path, like this: specs/env/spec.html, Envjs tries to convert this to a file: URL.  However, this wasn't working quite right in Windows beacuse getcwd() returns the wrong slash, and file:/// should have 3 slashes, not 2.
- Brian
