### PR TITLE
CSS2Properties uniqueness

### DIFF
--- a/envjs/css.js
+++ b/envjs/css.js
@@ -140,7 +140,7 @@ Envjs.once('tick', function(){
 
 exports.CSS2Properties = CSS2Properties = function(element){
     //console.log('css2properties %s', __cssproperties__++);
-    this.styleIndex = __supportedStyles__;//non-standard
+    this.styleIndex = __extend__({}, __supportedStyles__);//non-standard
     this.type = element.tagName;//non-standard
     __setArray__(this, []);
     __cssTextToStyles__(this, element.cssText || '');

--- a/specs/css/spec.js
+++ b/specs/css/spec.js
@@ -94,6 +94,16 @@ test('CSS2Properties', function(){
     equals(div.style.cssText, 'display: block; height: 300px; width: 400px; opacity: 0.5; position: absolute;', '.style.cssText');
 });
 
+test('CSS2Properties uniqueness', function(){
+    var div = document.createElement('div');
+    var div2 = document.createElement('div');
+    div.setAttribute('style', 'top:5px;');
+    div2.setAttribute('style', 'top:10px;');
+
+    equals(div.style.top, '5px');
+    equals(div2.style.top, '10px');
+});
+
 test('document.styleSheets', function() {
     ok(document.styleSheets, 'document.styleSheets exists');
     equals(document.styleSheets.toString(), '[object StyleSheetList]', 'StyleSheetsList.toString()');

--- a/src/css/properties.js
+++ b/src/css/properties.js
@@ -35,7 +35,7 @@ Envjs.once('tick', function(){
 
 exports.CSS2Properties = CSS2Properties = function(element){
     //console.log('css2properties %s', __cssproperties__++);
-    this.styleIndex = __supportedStyles__;//non-standard
+    this.styleIndex = __extend__({}, __supportedStyles__);//non-standard
     this.type = element.tagName;//non-standard
     __setArray__(this, []);
     __cssTextToStyles__(this, element.cssText || '');


### PR DESCRIPTION
All instances of CSS2Properties currently share an instance of a single object for this.styleIndex. This makes it so that if you set a style on divA, divB also reflects the change.

This patch addresses the issue by extending a new object with **supportedStyles** for each instance of CSS2Properties.
