### PR TITLE
Basic Windows support using Rhino engine

### DIFF
--- a/bin/debug.bat
+++ b/bin/debug.bat
@@ -1,0 +1,1 @@
+java -cp rhino/js.jar org.mozilla.javascript.tools.debugger.Main envjs/rhino.js %*

--- a/bin/envjs.bat
+++ b/bin/envjs.bat
@@ -1,0 +1,1 @@
+java -Xmx512M -jar rhino/js.jar -opt -1 envjs/rhino.js %*

--- a/specs/platform/core.js
+++ b/specs/platform/core.js
@@ -41,6 +41,8 @@ test('Envjs.uri', function(){
     ok(uri, 'Able to create uri');
     equals(uri, 'http://envjs.com/specs/env/spec.html', 'uri');
     equals(uri.toString(), 'http://envjs.com/specs/env/spec.html', 'uri');
+	
+	document = null;
 
     uri = Envjs.uri('http://envjs.com/specs/env/spec.html');
     ok(uri, 'Able to create uri');

--- a/specs/platform/core.js
+++ b/specs/platform/core.js
@@ -42,8 +42,6 @@ test('Envjs.uri', function(){
     equals(uri, 'http://envjs.com/specs/env/spec.html', 'uri');
     equals(uri.toString(), 'http://envjs.com/specs/env/spec.html', 'uri');
 
-    document = null;
-
     uri = Envjs.uri('http://envjs.com/specs/env/spec.html');
     ok(uri, 'Able to create uri');
     equals(uri, 'http://envjs.com/specs/env/spec.html', 'uri');
@@ -59,6 +57,15 @@ test('Envjs.uri', function(){
 
     uri = Envjs.uri('file:///foo/bar/');
     equals(uri, 'file:///foo/bar/', 'File, absolute, with ending "/"');
+	
+	// handle windows style file paths, firefox will convert this to a file: URL
+	uri = Envjs.uri('C:\\foo\\bar\\index.html');
+    equals(uri, 'file:///C:/foo/bar/index.html', 'File, absolute, converted slashes');
+
+	// when there is no document and you pass a relative path, it should be converted to a file: URL
+    document = null;
+    uri = Envjs.uri('specs/env/spec.html');
+    ok(/file\:\/\/\/.*\/specs\/env\/spec.html/.test(uri), 'Relative filesystem paths work');
 
     uri = Envjs.uri('http://foo.com');
     equals(uri, 'http://foo.com/', 'http, absolute, without path, without ending "/"');

--- a/src/platform/core/xhr.js
+++ b/src/platform/core/xhr.js
@@ -151,13 +151,15 @@ Envjs.localXHR = function(url, xhr, connection, data){
             xhr.statusText = "ok";
             xhr.responseText = Envjs.readFromFile(url);
             try{
-                if(url.match(/html$/)){
+                //url as passed in here might be an object, so stringify it
+                var urlstring = url.toString();
+                if(urlstring.match(/html$/)){
                     xhr.responseHeaders["Content-Type"] = 'text/html';
-                }else if(url.match(/.xml$/)){
+                }else if(urlstring.match(/.xml$/)){
                     xhr.responseHeaders["Content-Type"] = 'text/xml';
-                }else if(url.match(/.js$/)){
+                }else if(urlstring.match(/.js$/)){
                     xhr.responseHeaders["Content-Type"] = 'text/javascript';
-                }else if(url.match(/.json$/)){
+                }else if(urlstring.match(/.json$/)){
                     xhr.responseHeaders["Content-Type"] = 'application/json';
                 }else{
                     xhr.responseHeaders["Content-Type"] = 'text/plain';

--- a/src/platform/core/xhr.js
+++ b/src/platform/core/xhr.js
@@ -23,6 +23,7 @@ Envjs.getcwd = function() {
  * @param {Object} base  (semi-optional)  The base url used in resolving "path" above
  */
 Envjs.uri = function(path, base) {
+	path = path.replace(/\\/g, '/');
     //console.log('constructing uri from path %s and base %s', path, base);
     path = path+'';
     // Semi-common trick is to make an iframe with src='javascript:false'
@@ -35,6 +36,12 @@ Envjs.uri = function(path, base) {
     // if path is absolute, then just normalize and return
     if (path.match('^[a-zA-Z]+://')) {
         return urlparse.urlnormalize(path);
+    }
+
+    // if path is a Windows style absolute path (C:\foo\bar\index.html)
+	// make it a file: URL
+    if (path.match('^[a-zA-Z]+:/')) {
+        return 'file:///' + urlparse.urlnormalize(path);
     }
 
     // interesting special case, a few very large websites use
@@ -58,7 +65,7 @@ Envjs.uri = function(path, base) {
     // if base is still empty, then we are in QA mode loading local
     // files.  Get current working directory
     if (!base) {
-        base = 'file://' +  Envjs.getcwd() + '/';
+        base = 'file:///' + (""+Envjs.getcwd()).replace(/\\/g, '/') + '/';
     }
     // handles all cases if path is abosulte or relative to base
     // 3rd arg is "false" --> remove fragments


### PR DESCRIPTION
This pull request aims to get the current envjs to function from the command-line using the included Rhino platform. Three basic changes:
- "file:" URL formatting corrected (taken from the first two commits in moschel's pull request https://github.com/thatcher/env-js/pull/23 ).
- simple envjs.bat and debug.bat in the bin folder to launch under Rhino.
- bug fix (should apply to any Rhino instance, not just Windows) in Envjs.localXHR. Pattern matching was being performed on the URL in order to determine a content type, but when running under Rhino the URL parameter is a java.net.URL, not a string.

Basic envjs example (for example a simple test.html file, window.location="test.html"; in test.js, then "bin\envjs test.js") works on Windows after these three changes.
