### PR TITLE
Fix bug in Element.insertBefore()

### DIFF
--- a/src/dom/node.js
+++ b/src/dom/node.js
@@ -140,7 +140,7 @@ __extend__(Node.prototype, {
         }
         if(!refChild){
             this.appendChild(newChild);
-            return this.newChild;
+            return newChild;
         }
 
         // test for exceptions


### PR DESCRIPTION
If there is no `refChild` passed to `insertBefore()`, the function returns `undefined` instead of the `newChild`.
